### PR TITLE
BlogTagsLink.astro: duplicate font-size

### DIFF
--- a/src/components/BlogTagsLink.astro
+++ b/src/components/BlogTagsLink.astro
@@ -50,10 +50,8 @@ const { heading, tags } = Astro.props
   }
   .blog-tags-link ul li {
     position: relative;
-    font-size: 1rem;
     padding: 0.4rem;
     line-height: 1.2rem;
-
     font-size: 0.9rem;
     gap: 6px;
   }


### PR DESCRIPTION
Since font-size was duplicated, I have removed one of them.